### PR TITLE
パフォーマンス改善

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,5 +9,6 @@ resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/release
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.9",
   "com.lightbend.akka" %% "akka-stream-alpakka-csv" % "0.13",
-  "com.lightbend.akka" %% "akka-stream-alpakka-file" % "0.13"
+  "com.lightbend.akka" %% "akka-stream-alpakka-file" % "0.13",
+  "org.apache.commons" % "commons-lang3" % "3.7"
 )

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,12 @@
+csv-aggregate-dispatcher {
+  type = Dispatcher
+  executor = "fork-join-executor"
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 1.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 8
+  }
+}

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -1,7 +1,5 @@
-import java.nio.file.Paths
-
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategy}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl._
 import org.apache.commons.lang3.StringUtils
 

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -1,7 +1,7 @@
 import java.nio.file.Paths
 
 import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategy}
 import akka.stream.scaladsl._
 
 import scala.util.Success
@@ -9,7 +9,8 @@ import scala.util.Success
 
 object Main extends App {
   implicit val system = ActorSystem("MyAkkaActor")
-  implicit val materializer = ActorMaterializer()
+  val materializerSettings = ActorMaterializerSettings(system).withDispatcher("csv-aggregate-dispatcher")
+  implicit val materializer = ActorMaterializer(materializerSettings)
   implicit val dipatcher = system.dispatcher
 
 

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -2,9 +2,7 @@ import java.nio.file.Paths
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, OverflowStrategy}
-import akka.stream.alpakka.csv.scaladsl.{CsvParsing, CsvToMap}
 import akka.stream.scaladsl._
-import akka.util.ByteString
 
 import scala.util.Success
 
@@ -18,43 +16,46 @@ object Main extends App {
   // val path = if (params.isEmpty) "../fukuokaex/test_12_000_000.csv" else params(0)
   //val path = "../fukuokaex/test_3_000_000.csv"
   val path = "./test_3_000_000.csv"
-  val source = FileIO.fromPath(Paths.get(path))
+  val fileSource = scala.io.Source.fromFile(path, enc = "utf-8")
+  val source = Source.fromIterator(() => fileSource.getLines())
 
   val acc_empty = Map.empty[String, Int]
   var resultMap = Map.empty[String, Int]
   val grp_col = "lastname"
 
-  val groupSize = 8
+  val groupSize = 30
 
   val indexOfLastName = 1
 
   /** hashCode でグループ分け */
-  def extractGroupId(elem: ByteString) = {
+  def extractGroupId(elem: String) = {
     Math.abs(elem.hashCode()) % groupSize
   }
 
   val start = System.currentTimeMillis()
   source
-    .via(Framing.delimiter(ByteString('\n'), maximumFrameLength = Int.MaxValue))
     .async // 非同期でファイルを読み込む
+    .map(rec => rec.split(',')(indexOfLastName))
     .groupBy(groupSize, extractGroupId) // Group ごとに並列処理
     .buffer(10, OverflowStrategy.backpressure) // 下流に速度差がある場合に back pressure がかかるのを防止
-    .map(rec => rec.utf8String.split(',')(indexOfLastName))
     .async // 下流が他のステップと比べて重そうなので
     .fold(acc_empty) { (acc: Map[String, Int], rec: String) =>
       acc + (rec -> (acc.getOrElse(rec, 0) + 1))
     }
     .mergeSubstreams
     .runWith(Sink.fold(acc_empty) { (acc: Map[String, Int], rec: Map[String, Int]) =>
-      acc ++ rec.map { case (k, v) => k -> (v + acc.getOrElse(k, 0)) }
+      // LastName の hashCode でグループ分けしたので、acc と rec で同じキーの要素は存在しない
+      acc ++ rec
     })
     .onComplete {
       case Success(resultMap) ⇒
         val msec = (System.currentTimeMillis - start)
         resultMap.toSeq.sortWith(_._2 > _._2).take(10).foreach(println)
         println(msec + "msec")
+        fileSource.close()
         system.terminate()
       case _ =>
+        fileSource.close()
         system.terminate()
     }
 }

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -3,6 +3,7 @@ import java.nio.file.Paths
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, OverflowStrategy}
 import akka.stream.scaladsl._
+import org.apache.commons.lang3.StringUtils
 
 import scala.util.Success
 
@@ -35,7 +36,7 @@ object Main extends App {
 
   val start = System.currentTimeMillis()
   source
-    .map(rec => rec.split(",")(indexOfLastName))
+    .map(rec => StringUtils.split(rec, ",", indexOfLastName + 2)(indexOfLastName))
     .groupBy(groupSize, extractGroupId) // Group ごとに並列処理
     .buffer(10, OverflowStrategy.backpressure) // 下流に速度差がある場合に back pressure がかかるのを防止
     .fold(acc_empty) { (acc: Map[String, Int], rec: String) =>

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -22,10 +22,6 @@ object Main extends App {
   val fileSource = scala.io.Source.fromFile(path, enc = "utf-8")
   val source = Source.fromIterator(() => fileSource.getLines())
 
-  val acc_empty = Map.empty[String, Int]
-  var resultMap = Map.empty[String, Int]
-  val grp_col = "lastname"
-
   val groupSize = 30
 
   val indexOfLastName = 1

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -34,11 +34,9 @@ object Main extends App {
 
   val start = System.currentTimeMillis()
   source
-    .async // 非同期でファイルを読み込む
     .map(rec => rec.split(',')(indexOfLastName))
     .groupBy(groupSize, extractGroupId) // Group ごとに並列処理
     .buffer(10, OverflowStrategy.backpressure) // 下流に速度差がある場合に back pressure がかかるのを防止
-    .async // 下流が他のステップと比べて重そうなので
     .fold(acc_empty) { (acc: Map[String, Int], rec: String) =>
       acc + (rec -> (acc.getOrElse(rec, 0) + 1))
     }

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -35,7 +35,7 @@ object Main extends App {
 
   val start = System.currentTimeMillis()
   source
-    .map(rec => rec.split(',')(indexOfLastName))
+    .map(rec => rec.split(",")(indexOfLastName))
     .groupBy(groupSize, extractGroupId) // Group ごとに並列処理
     .buffer(10, OverflowStrategy.backpressure) // 下流に速度差がある場合に back pressure がかかるのを防止
     .fold(acc_empty) { (acc: Map[String, Int], rec: String) =>

--- a/src/main/scala/MyAkka.scala
+++ b/src/main/scala/MyAkka.scala
@@ -34,7 +34,6 @@ object Main extends App {
   source
     .map(rec => StringUtils.split(rec, ",", indexOfLastName + 2)(indexOfLastName)) // String#split は正規表現を用いるため効率が悪い
     .groupBy(groupSize, rec => Math.abs(rec.hashCode()) % groupSize) // String#hashCode を使って、名前ごとに一意の group にディスパッチされるようにする
-    .buffer(10, OverflowStrategy.backpressure) // 下流に速度差がある場合に back pressure がかかるのを防止
     .fold(AnyRefMap.empty[String, Int]) { (acc, rec: String) =>
       // 効率が良い AnyRefMap を使う
       acc.updated(rec, acc.getOrElse(rec, 0) + 1)


### PR DESCRIPTION
下記の通りプログラムを修正し、パフォーマンスを改善しました。

- ファイルの読込を Scala の標準ライブラリで行うよう変更
- CSVのパースをより単純な実装に変更
- ストリーム処理専用のディスパッチャ（スレッドプール）を割り当て
- アルファベット以外のデータも処理できるよう、`groupBy` のキーに `String#hashCode` の剰余を利用するよう変更
- Mapをより効率的に処理できる `AnyRefMap` に変更
- 最後の `fold` をMapの単純な結合に変更（同じキーは常に同じ group で集計されるため）

私の環境では約7倍処理速度が向上しました。

![image](https://user-images.githubusercontent.com/1239141/36943237-1abf5350-1fc9-11e8-9036-5a3388fbd60f.png)